### PR TITLE
install Jupyter kernel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,19 @@
 """Setup file for itango."""
 
+import json
+import os
 import platform
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+from shutil import rmtree
+import sys
+from tempfile import mkdtemp
+
+try:
+    from jupyter_client.kernelspec import KernelSpecManager
+    HAVE_JUPYTER = True
+except ImportError:
+    HAVE_JUPYTER = False
 
 
 def get_entry_points():
@@ -10,6 +22,40 @@ def get_entry_points():
     return {
         "console_scripts": ["{0} = itango:run".format(name)],
         "gui_scripts": ["{0}-qt = itango:run_qt".format(name)]}
+
+
+def install_jupyter_hook(prefix=None, root=None):
+    """Make ITango available as a Jupyter kernel."""
+    if not HAVE_JUPYTER:
+        print("No jupyter installation detected; not installing itango kernel.")
+        return
+    spec = {"argv": [sys.executable,
+                     "-m", "ipykernel",
+                     "--profile", "tango",
+                     "-f", "{connection_file}"],
+            "display_name": 'ITango %i' % sys.version_info[0],
+            "language": "python",
+            }
+    d = mkdtemp()
+    os.chmod(d, 0o755)  # Starts off as 700, not user readable
+    if sys.platform == 'win32':
+        # Ensure that conda-build detects the hard coded prefix
+        spec['argv'][0] = spec['argv'][0].replace(os.sep, os.altsep)
+    with open(os.path.join(d, 'kernel.json'), 'w') as f:
+        json.dump(spec, f, sort_keys=True, indent=4)
+    if 'CONDA_BUILD' in os.environ:
+        prefix = sys.prefix
+        if sys.platform == 'win32':
+            prefix = prefix.replace(os.sep, os.altsep)
+    user = ('--user' in sys.argv)
+    print('Installing Jupyter kernel spec:')
+    print('  root: {0!r}'.format(root))
+    print('  prefix: {0!r}'.format(prefix))
+    print('  as user: {0}'.format(user))
+    KernelSpecManager().install_kernel_spec(
+        d, 'itango%d' % sys.version_info[0], user=user,
+        replace=True, prefix=prefix)
+    rmtree(d)
 
 
 CLASSIFIERS = """\
@@ -22,6 +68,20 @@ Programming Language :: Python :: 2
 Programming Language :: Python :: 3
 Topic :: System :: Shells
 """.splitlines()
+
+
+class ITangoInstall(install):
+
+    def run(self):
+        root = self.root if self.root else None
+        prefix = self.prefix if self.prefix else None
+        try:
+            install_jupyter_hook(prefix=prefix, root=root)
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            print('Installing Jupyter hook failed.')
+        super().run()
 
 
 setup(
@@ -46,4 +106,5 @@ setup(
     download_url='http://pypi.python.org/pypi/itango',
     platforms=['Linux', 'Windows XP/Vista/7/8'],
     keywords=['PyTango', 'IPython'],
-    )
+    cmdclass={"install": ITangoInstall}
+)

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class ITangoInstall(install):
             import traceback
             traceback.print_exc()
             print('Installing Jupyter hook failed.')
-        super().run()
+        install.run(self)
 
 
 setup(


### PR DESCRIPTION
This adds an action to the setup script to automatically detect if Jupyter is installed and if so, installs ITango as a "kernel". This means that ITango can be selected in the Jupyter notebook interface when creating a new kernel.

It's really just an IPython kernel with the "tango" profile, just like ITango. I've tested it only a bit and it seems to work fine with completion and such. So far the only thing that really seems broken is the images, e.g. when you display a Device.

I'm not sure what I did here is the best way, I've tested with python 2.7 and 3.5, but maybe there will be issues with older versions of setuptools etc?