### PR TITLE
New compatibility policy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,14 @@ Requirements
 
 ITango is compatible with python 2 and 3. It requires:
 
--  IPython_ >= 1.0
 -  PyTango_ >= 9.2
+-  IPython_ >= 1.0
 
-.. note:: For IPython_ < 1.0 compatibilty, use `ITango 0.1.1`_.
+However, a compatiblity package is available as `itango-0.0.1`_.
+It provides compatibility for:
+
+- 7.2 <= PyTango_ < 9
+- 0.10 <= IPython_ < 5
 
 
 Install
@@ -30,7 +34,8 @@ Install
 
 ITango is available on PyPI_::
 
-    $ pip install itango
+    $ pip install itango         # latest version (tango 9)
+    $ pip install itango==0.0.1  # tango 8 compatibility
 
 
 Usage
@@ -72,7 +77,7 @@ Check out the documentation_ for more informations.
 
 .. _IPython: http://ipython.org/
 .. _ITango: http://pypi.python.org/pypi/itango/
-.. _ITango 0.1.1: https://pypi.python.org/pypi/itango/0.1.1
+.. _itango-0.0.1: https://pypi.python.org/pypi/itango/0.0.1
 .. _PyTango: https://github.com/tango-cs/PyTango
 .. _documentation: http://pythonhosted.org/itango
 

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,10 @@ Requirements
 
 ITango is compatible with python 2 and 3. It requires:
 
--  PyTango_ >= 7.2
--  IPython_ >= 1.0 (or >= 0.10 if used with PyTango <= 8.1.8)
+-  IPython_ >= 1.0
+-  PyTango_ >= 9.2
+
+.. note:: For IPython_ < 1.0 compatibilty, use `ITango 0.1.1`_.
 
 
 Install

--- a/itango/__init__.py
+++ b/itango/__init__.py
@@ -15,16 +15,9 @@ __all__ = ["install",
            "get_python_version", "get_ipython_version",
            "get_pytango_version"]
 
-try:
-    import tango
-except ImportError:
-    # PyTango <= 8.1.8
-    from PyTango.ipython import *
-    from PyTango.ipython import __path__
-else:
-    # PyTango >= 9.2
-    from .common import get_python_version, get_ipython_version
-    from .common import get_pytango_version
-    from .install import install
-    from .itango import load_ipython_extension, unload_ipython_extension
-    from .itango import init_ipython, load_config, run, run_qt
+from .common import get_python_version, get_ipython_version
+from .common import get_pytango_version
+
+from .install import install
+from .itango import load_ipython_extension, unload_ipython_extension
+from .itango import init_ipython, load_config, run, run_qt

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
         'resource/*.png', 'resource/*.svg']},
     entry_points=get_entry_points(),
     install_requires=[
-        'IPython>=0.10',
-        'PyTango>=7.2'],
+        'IPython>=1.0',
+        'pytango>=9.2.0'],
 
     license='LGPL',
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
As discussed in issue #8:

- [tango8 branch](https://github.com/tango-cs/itango/tree/tango8): `itango-0.0.1` compatibility package requires:
  - `IPython >= 0.10, < 5` 
  - `PyTango >= 7.2, < 9`
- master branch: `itango-0.1.6` and above requires:
  - `IPython>=1.0` 
  - `pytango>=9.2.0`